### PR TITLE
feat(#5): openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ RUN apt-get -y install ssh \
   && mkdir /var/run/sshd \
   && chmod 0755 /var/run/sshd
 
+# OpenSSL
+RUN apt-get -y install libssl-dev
+
 # Java
 ENV MAVEN_OPTS "-Xmx1g"
 ENV JAVA_OPTS "-Xmx1g"


### PR DESCRIPTION
related to #5 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the installation of `libssl-dev` to the Dockerfile and sets Maven and Java options. 

### Detailed summary
- Added installation of `libssl-dev` to Dockerfile
- Set `MAVEN_OPTS` to "-Xmx1g"
- Set `JAVA_OPTS` to "-Xmx1g"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->